### PR TITLE
Add last seen timestamp to sensor data

### DIFF
--- a/custom_components/whats_that_plane/sensor.py
+++ b/custom_components/whats_that_plane/sensor.py
@@ -304,6 +304,7 @@ class WhatsThatPlaneSensor(CoordinatorEntity, SensorEntity):
             "estimated_arrival_delay_mins": estimated_arrival_delay_mins,
             "arrival_delay_mins": arrival_delay_mins,
 
+            "last_seen_timestamp": last_seen_timestamp,
             "last_seen_time_formatted": last_seen_time_formatted,
         }
 


### PR DESCRIPTION
This pull request makes a small update to the flight data formatting in the `sensor.py` file for the `whats_that_plane` custom component. The change adds a new field to the formatted flight data.

* Added the `last_seen_timestamp` field to the dictionary returned by `_format_flight_data`, allowing consumers to access the raw timestamp of when the flight was last seen.